### PR TITLE
Fixed unclosed div that caused extra row padding on portfolio

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -6,6 +6,7 @@
                 <div class="col-lg-12 text-center">
                     <h2>Portfolio</h2>
                     <hr class="star-primary">
+                </div>
             </div>
             <div class="row">
                 {% for post in site.posts %}


### PR DESCRIPTION
Extra row padding caused the body to be horizontally scrollable when on a mobile device.
