### PR TITLE
Use formspree for contact form instead of PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Jekyll theme based on [Freelancer bootstrap theme ](http://startbootstrap.com/te
 
 ## How to use
  - Place a image in `/img/portoflio/`
+ - Replace `you@email.com` in `_includes/contact_static.html` with your email address. refer to [formspree](http://formspree.io/) for more information.
  - Create posts to display your projects. Use the follow as an example:
 ```txt
 ---

--- a/_includes/contact_static.html
+++ b/_includes/contact_static.html
@@ -9,9 +9,7 @@
 		</div>
 		<div class="row">
 			<div class="col-lg-8 col-lg-offset-2">
-				<!-- To configure the contact form email address, go to mail/contact_me.php and update the email address in the PHP file on line 19. -->
-				<!-- The form should work on most web servers, but if the form is not working you may need to configure your web server differently. -->
-				<form  action="//formspree.io/<your-email-here>" method="POST" name="sentMessage" id="contactForm" novalidate>
+				<form  action="//formspree.io/you@email.com" method="POST" name="sentMessage" id="contactForm" novalidate>
 					<div class="row control-group">
 						<div class="form-group col-xs-12 floating-label-form-group controls">
 							<label>Name</label>


### PR DESCRIPTION
[Formspree.io](http://formspree.io/) sends emails for static sites. This is helpful if you're using a web server that doesn't support PHP. You dont need to register and it is really pain free. 

However to my knowledge Formspree does not support a phone number field.