### PR TITLE
Color Fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ contact: static
 # Color settings (hex-codes without the leading hash-tag)
 color:
   primary: 18bc9c #80B3FF
+  primary-rgb: "24,288,156" #"128,179,255"
   secondary: 2c3e50 #FD6E8A
   secondary-dark: 233140 #A2122F
 

--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -211,7 +211,7 @@ section.success {
     width: 100%;
     height: 100%;
     opacity: 0;
-    background: rgba(24,188,156,.9);
+    background: rgba({{ site.color.primary-rgb }},.9);
     -webkit-transition: all ease .5s;
     -moz-transition: all ease .5s;
     transition: all ease .5s;
@@ -442,4 +442,8 @@ footer .footer-below {
     -webkit-transform: rotate(90deg);
     -ms-transform: rotate(90deg);
     transform: rotate(90deg);
+}
+
+.navbar-nav>.active>a {
+    background-color: #{{ site.color.secondary-dark }} !important;
 }


### PR DESCRIPTION
When you change the colors in the _config.yml file, there were 2 items that were still hardcoded in the css files:

- when you hover over a portfolio item
- the active item in the menu bar

For the portfolio item the color has to be in RGB, because it uses alpha, I added an extra variable in the config file with the RGB value of the primary color. I didn't change all the colors to RGB because that would be a lot of work.