### PR TITLE
Remove leading forward slashes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,10 +8,10 @@
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml">
 
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->
-    <link rel="stylesheet" href="{{ "/style.css" }}">
+    <link rel="stylesheet" href="{{ "style.css" }}">
 
     <!-- Custom Fonts -->
-    <link rel="stylesheet" href="{{ "/css/font-awesome/css/font-awesome.min.css" }}">
+    <link rel="stylesheet" href="{{ "css/font-awesome/css/font-awesome.min.css" }}">
     <link href="//fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,21 +1,21 @@
  <!-- jQuery Version 1.11.0 -->
-    <script src="{{ "/js/jquery-1.11.0.js" }}"></script>
+    <script src="{{ "js/jquery-1.11.0.js" }}"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="{{ "/js/bootstrap.min.js" }}"></script>
+    <script src="{{ "js/bootstrap.min.js" }}"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="{{ "/js/jquery.easing.min.js" }}"></script>
-    <script src="{{ "/js/classie.js" }}"></script>
-    <script src="{{ "/js/cbpAnimatedHeader.js" }}"></script>
+    <script src="{{ "js/jquery.easing.min.js" }}"></script>
+    <script src="{{ "js/classie.js" }}"></script>
+    <script src="{{ "js/cbpAnimatedHeader.js" }}"></script>
 
     <!-- Contact Form JavaScript -->
-    <script src="{{ "/js/jqBootstrapValidation.js" }}"></script>
+    <script src="{{ "js/jqBootstrapValidation.js" }}"></script>
     {% if site.contact == "static" %}
-    <script src="{{ "/js/contact_me_static.js" }}"></script>
+    <script src="{{ "js/contact_me_static.js" }}"></script>
     {% else %}
-     <script src="{{ "/js/contact_me.js" }}"></script>
+     <script src="{{ "js/contact_me.js" }}"></script>
     {% endif %}
 
     <!-- Custom Theme JavaScript -->
-    <script src="{{ "/js/freelancer.js" }}"></script>
+    <script src="{{ "js/freelancer.js" }}"></script>


### PR DESCRIPTION
Removing these forward slashes will make the theme render properly on
gh-pages. Before, gh-pages would render a styleless / js-free site.
Removing the forward slashes does not affect the local environment.