### PR TITLE
Remove forward slashes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,13 +8,13 @@
 
 
     <!-- Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->
-    <link rel="stylesheet" href="{{ "/css/bootstrap.min.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "css/bootstrap.min.css" | prepend: site.baseurl }}">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "css/main.css" | prepend: site.baseurl }}">
 
     <!-- Custom Fonts -->
-    <link rel="stylesheet" href="{{ "/css/font-awesome/css/font-awesome.min.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "css/font-awesome/css/font-awesome.min.css" | prepend: site.baseurl }}">
     <link href="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href="http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,17 +1,17 @@
  <!-- jQuery Version 1.11.0 -->
-    <script src="{{ "/js/jquery-1.11.0.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/jquery-1.11.0.js" | prepend: site.baseurl }}"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="{{ "/js/bootstrap.min.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/bootstrap.min.js" | prepend: site.baseurl }}"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="{{ "/js/jquery.easing.min.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/js/classie.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/js/cbpAnimatedHeader.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/jquery.easing.min.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/classie.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/cbpAnimatedHeader.js" | prepend: site.baseurl }}"></script>
 
     <!-- Contact Form JavaScript -->
-    <script src="{{ "/js/jqBootstrapValidation.js" | prepend: site.baseurl }}"></script>
-    <script src="{{ "/js/contact_me.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/jqBootstrapValidation.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/contact_me.js" | prepend: site.baseurl }}"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="{{ "/js/freelancer.js" | prepend: site.baseurl }}"></script>
+    <script src="{{ "js/freelancer.js" | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
Removing these forward slashes will make the theme render properly on
gh-pages. Before, gh-pages would render a styleless / js-free site.
Removing the forward slashes does not affect the local environment.