### PR TITLE
Add suggested image size to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Freelancer Jekyll theme
 Jekyll theme based on [Freelancer bootstrap theme ](http://startbootstrap.com/template-overviews/freelancer/)
 
 ## How to use
- - Place a image in `/img/portfolio/`
+ - Place a image in `/img/portfolio/` (recommended image size: 900 x 650)
  - Replace `you@email.com` in `_includes/contact_static.html` with your email address. refer to [formspree](http://formspree.io/) for more information.
  - Create posts to display your projects. Use the follow as an example:
 ```txt


### PR DESCRIPTION
Using 512x512 icons from the same icon set, the formatting of my portfolio rows got messed up because the image didn't match the size in the demo (900 x 650). Having this in the readme would've saved me a lot of time, hence this change.