### PR TITLE
Fix site title attribute logic

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <title>{{ site.title }}</title>
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
     <meta name="keywords" content="{{ site.keywords }}" />


### PR DESCRIPTION
The site title attribute had some logic that would change the site title if a project modal was open, but it caused the title to permanently be set to the title of the last entry in the _posts directory. I removed the if/else logic to keep the site title to be what is specified in _config.yml in the "title" field.