### PR TITLE
Remove root-relative references that break the theme (should fix #114)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,10 +7,10 @@
     <meta name="keywords" content="{{ site.keywords }}" />
     {% if site.meta_author %}<meta name="author" content="{{ site.meta_author }}">{% endif %}
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="feed.xml">
 
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->
-    <link rel="stylesheet" href="{{ "/style.css" }}">
+    <link rel="stylesheet" href="{{ "style.css" }}">
 
     <!-- Google verification -->
     {% if site.google_verify %}<meta name="google-site-verification" content="{{ site.google_verify }}">{% endif %}
@@ -19,7 +19,7 @@
     {% if site.bing_verify %}<meta name="msvalidate.01" content="{{ site.bing_verify }}">{% endif %}
 
     <!-- Custom Fonts -->
-    <link rel="stylesheet" href="{{ "/css/font-awesome/css/font-awesome.min.css" }}">
+    <link rel="stylesheet" href="{{ "css/font-awesome/css/font-awesome.min.css" }}">
     <link href="//fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -1,24 +1,24 @@
  <!-- jQuery Version 1.11.0 -->
-    <script src="{{ "/js/jquery-1.11.0.js" }}"></script>
+    <script src="{{ "js/jquery-1.11.0.js" }}"></script>
 
     <!-- Bootstrap Core JavaScript -->
-    <script src="{{ "/js/bootstrap.min.js" }}"></script>
+    <script src="{{ "js/bootstrap.min.js" }}"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="{{ "/js/jquery.easing.min.js" }}"></script>
-    <script src="{{ "/js/classie.js" }}"></script>
-    <script src="{{ "/js/cbpAnimatedHeader.js" }}"></script>
+    <script src="{{ "js/jquery.easing.min.js" }}"></script>
+    <script src="{{ "js/classie.js" }}"></script>
+    <script src="{{ "js/cbpAnimatedHeader.js" }}"></script>
 
     <!-- Contact Form JavaScript -->
-    <script src="{{ "/js/jqBootstrapValidation.js" }}"></script>
+    <script src="{{ "js/jqBootstrapValidation.js" }}"></script>
     {% if site.contact == "static" %}
-    <script src="{{ "/js/contact_me_static.js" }}"></script>
+    <script src="{{ "js/contact_me_static.js" }}"></script>
     {% else %}
-     <script src="{{ "/js/contact_me.js" }}"></script>
+     <script src="{{ "js/contact_me.js" }}"></script>
     {% endif %}
 
     <!-- Custom Theme JavaScript -->
-    <script src="{{ "/js/freelancer.js" }}"></script>
+    <script src="{{ "js/freelancer.js" }}"></script>
 
     {% if site.contact == "disqus" %}
     <!-- Disqus Stuff -->


### PR DESCRIPTION
GitHub Pages is currently attempting to load CSS and JS from the root site, i.e yourusername.github.io, and as such it breaks. I removed the root-relative references, and it should work on every site now.

I hadn't checked for issues when I did this, and later found out about #114. This should help close the issue, I tested it on my own deployment (https://avonnaire.github.io/freelancer-theme/) and it seems to work.
On the issue there is another solution described which I have not tried, if you feel the way I currently implemented it is not as Jekyll-esque as it should be, I'll try that next. Nothing should break with the current change, though.