### PR TITLE
Adding html-proofer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gemspec
+gem 'html-proofer'


### PR DESCRIPTION
Added the `gem 'html-proofer'` line to the Gemfile so that it can be installed with `bundle install`.